### PR TITLE
Add Gordon Athletics schedule endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,7 @@ from flask.ext.cors import CORS, cross_origin
 
 import config
 import services
+from athleticsschedule import *
 from chapelcredits import *
 from checklogin import *
 from chapelevents import *

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -48,4 +48,8 @@ def parse_athletics_rss(feed):
 
 def get_cached_athletics_schedule():
     """Get cached athletics schedule from database."""
-    return db.get_doc('cache')[CACHE_KEY]
+    try:
+        return db.get_doc('cache')[CACHE_KEY]
+    except KeyError:
+        print "Could not find cached athletics schedule."
+        raise

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -81,7 +81,7 @@ def parse_athletics_event(item):
 
     local_start_date = get_tag_string(item, 's:localstartdate')
     datetime = arrow.get(local_start_date)
-    datetime_string = datetime.format(config.DATETIME_FORMAT)
+    datetime_string = datetime.format(config.DISPLAY_DATETIME_FORMAT)
     datetime_relative = date.make_relative_date(datetime)
 
     event = {

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -1,0 +1,46 @@
+"""Get Gordon Athletics schedule."""
+import requests
+import arrow
+import config
+from api.services import db
+
+URL = "http://athletics.gordon.edu/calendar.ashx/calendar.rss?sport_id=&han="
+CACHE_KEY = "athleticsSchedule"
+
+
+def get_athletics_schedule(username, password):
+    """Get Gordon Athletics schedule."""
+    time_now = arrow.now(config.TIMEZONE)
+    athletics_schedule = get_cached_athletics_schedule()
+
+    # Get expiration time from cached data
+    try:
+        time_expiration = arrow.get(
+            athletics_schedule['expiration'],
+            config.DATETIME_FORMAT)
+    except arrow.parser.ParserError:
+        time_expiration = None
+
+    # If data is expired, get fresh data from website
+    if time_now > time_expiration:
+        try:
+            feed = requests.get(URL)
+            athletics_schedule = parse_athletics_rss(feed)
+        except Exception as err:
+            print "Error getting athletics schedule!"
+        else:
+            db.cache_app_data(CACHE_KEY,
+                              athletics_schedule,
+                              config.UPDATE_INTERVAL['ATHLETICS_SCHEDULE'])
+    return {
+        'data': athletics_schedule
+    }
+
+
+def parse_athletics_rss(feed):
+    """Parse athletics RSS feed into a dict."""
+
+
+def get_cached_athletics_schedule():
+    """Get cached athletics schedule from database."""
+    return db.get_doc('cache')[CACHE_KEY]

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -5,7 +5,7 @@ import arrow
 import config
 from api.services import db
 
-URL = "http://athletics.gordon.edu/calendar.ashx/calendar.rss?sport_id=&han="
+URL = "http://athletics.gordon.edu/calendar.ashx/calendar.rss"
 CACHE_KEY = "athleticsSchedule"
 
 # Create fake header to circumvent user agent filtering

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -54,7 +54,8 @@ def parse_athletics_rss(feed):
 
     for item in rss_data.find_all('item'):
         event = parse_athletics_event(item)
-        athletics_schedule.append(event)
+        if event is not None:
+            athletics_schedule.append(event)
 
     return athletics_schedule
 

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -5,6 +5,7 @@ import requests
 import arrow
 import config
 from api.services import db
+from api.services import date
 
 URL = "http://athletics.gordon.edu/calendar.ashx/calendar.rss"
 CACHE_KEY = "athleticsSchedule"
@@ -89,6 +90,7 @@ def parse_athletics_event(item):
         'location': location,
         'opponentLogoURL': opponent_logo_url,
         'datetime': datetime_string,
+        'relative': datetime_relative
     }
 
     # Replace empty string values with explanatory string

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -28,12 +28,12 @@ def get_athletics_schedule(username, password):
     # If data is expired, get fresh data from website
     if time_now > time_expiration:
         try:
-            feed = requests.get(URL)
-            athletics_schedule = parse_athletics_rss(feed)
             response = requests.get(URL, headers=HEADERS)
+            response.raise_for_status()
         except Exception as err:
-            print "Error getting athletics schedule!"
+            raise ValueError("Could not retrieve athletics calendar: " + err)
         else:
+            athletics_schedule = parse_athletics_rss(response.text)
             db.cache_app_data(CACHE_KEY,
                               athletics_schedule,
                               config.UPDATE_INTERVAL['ATHLETICS_SCHEDULE'])

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -34,12 +34,12 @@ def get_athletics_schedule(username, password):
         except Exception as err:
             raise ValueError("Could not retrieve athletics calendar: " + err)
         else:
-            athletics_schedule = parse_athletics_rss(response.text)
+            athletics_schedule['schedule'] = parse_athletics_rss(response.text)
             db.cache_app_data(CACHE_KEY,
                               athletics_schedule,
                               config.UPDATE_INTERVAL['ATHLETICS_SCHEDULE'])
     return {
-        'data': athletics_schedule
+        'data': athletics_schedule['schedule']
     }
 
 

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -94,11 +94,11 @@ def parse_athletics_event(item):
     }
 
     # Replace empty string values with explanatory string
-    string_keys = ['title', 'location', 'time']
+    string_keys = ['title', 'location', 'datetime', 'relative']
     error_explanation = "Unknown"
     for key, value in event.iteritems():
         if key in string_keys and value is None:
-            event[key] = error_explanation
+            event[key] = key.capitalize() + ' ' + error_explanation
 
     # Only return event if it has not happened yet
     if datetime > arrow.now():

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -81,13 +81,14 @@ def parse_athletics_event(item):
     local_start_date = get_tag_string(item, 's:localstartdate')
     datetime = arrow.get(local_start_date)
     datetime_string = datetime.format(config.DATETIME_FORMAT)
+    datetime_relative = date.make_relative_date(datetime)
 
     event = {
         'title': title,
         'url': url,
         'location': location,
         'opponentLogoURL': opponent_logo_url,
-        'time': datetime_string
+        'datetime': datetime_string,
     }
 
     # Replace empty string values with explanatory string

--- a/api/athleticsschedule.py
+++ b/api/athleticsschedule.py
@@ -1,4 +1,5 @@
 """Get Gordon Athletics schedule."""
+from fake_useragent import UserAgent
 import requests
 import arrow
 import config
@@ -6,6 +7,9 @@ from api.services import db
 
 URL = "http://athletics.gordon.edu/calendar.ashx/calendar.rss?sport_id=&han="
 CACHE_KEY = "athleticsSchedule"
+
+# Create fake header to circumvent user agent filtering
+HEADERS = {'User-Agent': UserAgent().chrome}
 
 
 def get_athletics_schedule(username, password):
@@ -26,6 +30,7 @@ def get_athletics_schedule(username, password):
         try:
             feed = requests.get(URL)
             athletics_schedule = parse_athletics_rss(feed)
+            response = requests.get(URL, headers=HEADERS)
         except Exception as err:
             print "Error getting athletics schedule!"
         else:

--- a/api/chapelevents.py
+++ b/api/chapelevents.py
@@ -3,9 +3,9 @@ import mechanize
 import httplib
 import urllib2
 import arrow
-from datetime import datetime
 from bs4 import BeautifulSoup
 from api.services import db
+from api.services import date
 import config
 
 CHAPEL_DATE_FORMAT = 'MM/DD/YYYY'
@@ -64,38 +64,6 @@ def get_cached_chapel_events():
     return db.get_doc('cache')['chapelEvents']
 
 
-def make_relative_date(date_time):
-    """Make a relative date string from a datetime."""
-    current_date_time = datetime.now()
-    time_until = date_time.naive - current_date_time
-    hours_until = time_until.days * 24 + time_until.seconds // 3600
-
-    # If any time next week, get weekday names
-    if time_until.days > 1 and time_until.days < 7:
-        relative_date = date_time.format('dddd')
-
-        # Prepend 'next' to weekday name if next week
-        current_week_number = current_date_time.isocalendar()[1]
-        week_number = date_time.isocalendar()[1]
-        if week_number > current_week_number:
-            relative_date = "next " + relative_date
-
-    # If under 24 hours until and not current day, return "tomorrow"
-    elif (hours_until < 24 and
-          date_time.datetime.day != current_date_time.day):
-        relative_date = "tomorrow"
-
-    # Otherwise use default humanize output
-    else:
-        # Explicit use of current time to prevent timezone errors
-        relative_date = date_time.humanize(current_date_time)
-
-        if relative_date == "in a day":
-            relative_date = "tomorrow"
-
-    return relative_date
-
-
 def parse_chapel_events(browser):
     """Parse chapel events from retrieved page."""
     page = BeautifulSoup(browser.response().read())
@@ -131,8 +99,7 @@ def parse_chapel_events(browser):
                                    CHAPEL_DATETIME_FORMAT)
 
         # Create description of how long until event
-        # Add five hours to event_datetime to fix timezone problem
-        event_relative = make_relative_date(event_datetime)
+        event_relative = date.make_relative_date(event_datetime)
 
         event_data = {
             'title': event_title,

--- a/api/services/__init__.py
+++ b/api/services/__init__.py
@@ -4,3 +4,4 @@ from getcredentials import *
 from db import *
 from log import *
 from logingogordon import *
+from date import *

--- a/api/services/date.py
+++ b/api/services/date.py
@@ -1,0 +1,34 @@
+"""Handle operations on datetime objects."""
+from datetime import datetime
+
+
+def make_relative_date(date_time):
+    """Make a relative date string from a datetime."""
+    current_date_time = datetime.now()
+    time_until = date_time.naive - current_date_time
+    hours_until = time_until.days * 24 + time_until.seconds // 3600
+
+    # If any time next week, get weekday names
+    if time_until.days > 1 and time_until.days < 7:
+        relative_date = date_time.format('dddd')
+
+        # Prepend 'next' to weekday name if next week
+        current_week_number = current_date_time.isocalendar()[1]
+        week_number = date_time.isocalendar()[1]
+        if week_number > current_week_number:
+            relative_date = "next " + relative_date
+
+    # If under 24 hours until and not current day, return "tomorrow"
+    elif (hours_until < 24 and
+          date_time.datetime.day != current_date_time.day):
+        relative_date = "tomorrow"
+
+    # Otherwise use default humanize output
+    else:
+        # Explicit use of current time to prevent timezone errors
+        relative_date = date_time.humanize(current_date_time)
+
+        if relative_date == "in a day":
+            relative_date = "tomorrow"
+
+    return relative_date

--- a/config.py
+++ b/config.py
@@ -10,7 +10,8 @@ WENHAM_LONGITUDE = -70.824631
 # Time to wait between cache updates, in minutes
 UPDATE_INTERVAL = {
     "WEATHER": 15,
-    "CHAPEL_EVENTS": 60
+    "CHAPEL_EVENTS": 60,
+    "ATHLETICS_SCHEDULE": 60
 }
 
 PAPERTRAIL_URL = 'logs2.papertrailapp.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ arrow==0.6.0
 beautifulsoup4==4.3.2
 CouchDB==1.0
 eventlet==0.17.4
+fake-useragent==0.0.8
 Flask==0.10.1
 Flask-Cors==1.10.2
 greenlet==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ gunicorn==19.2.1
 itsdangerous==0.24
 Jinja2==2.7.3
 logging==0.4.9.6
-lxml==3.5.0
 MarkupSafe==0.23
 mechanize==0.2.5
 newrelic==2.46.0.37

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ gunicorn==19.2.1
 itsdangerous==0.24
 Jinja2==2.7.3
 logging==0.4.9.6
+lxml==3.5.0
 MarkupSafe==0.23
 mechanize==0.2.5
 newrelic==2.46.0.37

--- a/run.py
+++ b/run.py
@@ -252,6 +252,22 @@ def route_chapel_events(version):
         return "Chapel events endpoint is working."
 
 
+@app.route(END_POINT_PREFIX + 'athleticsschedule',
+           methods=['GET', 'POST', 'HEAD'])
+def route_athletics_schedule(version):
+    """Handle requests for athletics schedule."""
+    if request.data or request.args:
+        request_info = {
+            'args': request.args or request.get_json(),
+            'endpoint': 'athleticsSchedule',
+            'version': version
+        }
+        return get_data(get_athletics_schedule, request_info,
+                        shouldCache=False)
+    else:
+        return "Athletics schedule endpoint is working."
+
+
 @app.route(END_POINT_PREFIX + 'mockerror',
            methods=['GET', 'POST', 'HEAD'])
 def route_mock_error(version):


### PR DESCRIPTION
Add an endpoint to provide the Gordon Athletics schedule, publicly available on [the Gordon Athletics website](http://athletics.gordon.edu/calendar.aspx) and in [RSS format](http://athletics.gordon.edu/calendar.ashx/calendar.rss?sport_id=&han=).
